### PR TITLE
Implement custom marshalers

### DIFF
--- a/map.go
+++ b/map.go
@@ -152,7 +152,7 @@ func (m Map) MarshalJSON() (bs []byte, err error) {
 
 // UnmarshalJSON is a JSON decoding helper func
 func (m *Map) UnmarshalJSON(bs []byte) (err error) {
-	nm := Map{}
+	nm := make(Map, countItems(bs))
 	if err = forEachKey(bs, func(key string) {
 		nm.Set(key)
 	}); err != nil {

--- a/map.go
+++ b/map.go
@@ -125,7 +125,25 @@ func (m Map) IsMatch(a Map) (isMatch bool) {
 
 // MarshalJSON is a JSON encoding helper func
 func (m Map) MarshalJSON() (bs []byte, err error) {
-	return json.Marshal(m.Slice())
+	ref := make([]byte, 0, 32)
+	ref = append(ref, '[')
+	var seenFirst bool
+	for key := range m {
+		if !seenFirst {
+			seenFirst = true
+		} else {
+			ref = append(ref, ',')
+		}
+
+		ref = append(ref, '"')
+		ref = append(ref, key...)
+		ref = append(ref, '"')
+
+	}
+
+	ref = append(ref, ']')
+	bs = ref
+	return
 }
 
 // UnmarshalJSON is a JSON decoding helper func
@@ -144,5 +162,27 @@ func (m *Map) UnmarshalJSON(bs []byte) (err error) {
 func (m *Map) SetAsString(value string) (err error) {
 	spl := strings.Split(value, ",")
 	m.SetMany(spl)
+	return
+}
+
+func (m Map) getJSONBytesLength() (length int) {
+	// Increment length by two for surrounding brackets
+	length += 2
+
+	if len(m) == 0 {
+		return
+	}
+
+	for key := range m {
+		// Increment for length of key
+		length += len(key)
+		// Increment length
+		length += 2
+		// Increment length by one for comma
+		length += 1
+	}
+
+	// Decrement so we don't account for trailing comma
+	length -= 1
 	return
 }

--- a/map.go
+++ b/map.go
@@ -127,7 +127,7 @@ func (m Map) IsMatch(a Map) (isMatch bool) {
 // MarshalJSON is a JSON encoding helper func
 func (m Map) MarshalJSON() (bs []byte, err error) {
 	var seenFirst bool
-	bs = make([]byte, 0, 32)
+	bs = make([]byte, 0, 16*len(m))
 	bs = append(bs, '[')
 	for key := range m {
 		if !seenFirst {

--- a/utils.go
+++ b/utils.go
@@ -1,0 +1,71 @@
+package stringset
+
+import (
+	"fmt"
+)
+
+const (
+	stateStart uint8 = iota
+	statePreQuote
+	stateValue
+	stateEscape
+	statePostQuote
+)
+
+func forEachKey(bs []byte, fn func(key string)) (err error) {
+	if len(bs) == 0 {
+		return
+	}
+
+	var state uint8
+	keyBuf := make([]byte, 0, 32)
+	for i := 0; i < len(bs); i++ {
+		char := bs[i]
+		switch state {
+		case stateStart:
+			switch char {
+			case '[':
+				state = statePreQuote
+			default:
+				return fmt.Errorf("invalid character, expected <[>, received <%s>", string(char))
+			}
+		case statePreQuote:
+			switch char {
+			case '"':
+				state = stateValue
+			case ' ', '\t':
+			default:
+				return fmt.Errorf("invalid character, expected <\">, < >, or <\t>, received <%s>", string(char))
+			}
+
+		case stateValue:
+			switch char {
+			case '\\':
+				state = stateEscape
+			case '"':
+				state = statePostQuote
+			default:
+				keyBuf = append(keyBuf, char)
+			}
+
+		case stateEscape:
+			keyBuf = append(keyBuf, char)
+			state = stateValue
+
+		case statePostQuote:
+			fn(string(keyBuf))
+			keyBuf = keyBuf[:0]
+
+			switch char {
+			case ',':
+				state = statePreQuote
+			case ']':
+				return
+			default:
+				return fmt.Errorf("invalid character, expected <,> or <]>, received <%s>", string(char))
+			}
+		}
+	}
+
+	return
+}

--- a/utils.go
+++ b/utils.go
@@ -69,3 +69,14 @@ func forEachKey(bs []byte, fn func(key string)) (err error) {
 
 	return
 }
+
+func countItems(bs []byte) (count int) {
+	for _, b := range bs {
+		if b == ',' {
+			count++
+		}
+	}
+
+	count++
+	return
+}

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,0 +1,70 @@
+package stringset
+
+import (
+	"errors"
+	"testing"
+)
+
+func Test_forEachKey(t *testing.T) {
+	type testcase struct {
+		str       string
+		wanted    []string
+		wantedErr error
+	}
+
+	tcs := []testcase{
+		{
+			str:       `["foo","bar","baz"]`,
+			wanted:    []string{"foo", "bar", "baz"},
+			wantedErr: nil,
+		},
+		{
+			str:       `["foo","bar","baz",]`,
+			wanted:    []string{"foo", "bar", "baz"},
+			wantedErr: errors.New("invalid character, expected <\">, < >, or <\t>, received <]>"),
+		},
+
+		{
+			str:       `{"foo":1,"bar":2,"baz":3}`,
+			wanted:    []string{},
+			wantedErr: errors.New("invalid character, expected <[>, received <{>"),
+		},
+	}
+
+	for _, tc := range tcs {
+		var count int
+		err := forEachKey([]byte(tc.str), func(key string) {
+			if count+1 > len(tc.wanted) {
+				t.Fatalf("exceeded wanted count, expected %d entries <%s>", len(tc.wanted), tc.str)
+			}
+
+			if tc.wanted[count] != key {
+				t.Fatalf("invalid key, expected <%s> and received <%s>", tc.wanted[count], key)
+			}
+
+			count++
+		})
+
+		if !checkErr(tc.wantedErr, err) {
+			t.Fatalf("invalid error, expected\n<%v> and received\n<%v>", tc.wantedErr, err)
+		}
+
+		if count != len(tc.wanted) {
+			t.Fatalf("invalid number of entries, expected %d and received %d", len(tc.wanted), count)
+		}
+	}
+}
+
+func checkErr(a, b error) bool {
+	switch {
+	case a == nil && b == nil:
+		return true
+	case a == nil && b != nil:
+		return false
+	case a != nil && b == nil:
+		return false
+
+	default:
+		return a.Error() == b.Error()
+	}
+}


### PR DESCRIPTION
The previous method used for Marshaling and Unmarshaling was not as efficient as it could be. The purpose of this PR is to remove the inefficiencies of serialization to and from JSON.

```
name                 old time/op    new time/op    delta
Map_MarshalJSON-4      14.2µs ± 0%     4.4µs ± 0%   ~     (p=1.000 n=1+1)
Map_UnmarshalJSON-4    46.6µs ± 0%    17.6µs ± 0%   ~     (p=1.000 n=1+1)

name                 old alloc/op   new alloc/op   delta
Map_MarshalJSON-4      4.13kB ± 0%    2.05kB ± 0%   ~     (p=1.000 n=1+1)
Map_UnmarshalJSON-4    14.9kB ± 0%     7.5kB ± 0%   ~     (p=1.000 n=1+1)

name                 old allocs/op  new allocs/op  delta
Map_MarshalJSON-4        3.00 ± 0%      1.00 ± 0%   ~     (p=1.000 n=1+1)
Map_UnmarshalJSON-4       154 ± 0%       131 ± 0%   ~     (p=1.000 n=1+1)
```